### PR TITLE
Add instructions on creating a rails plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Benjamin Franklin
 
 ## Starting New Projects
 
-- [New Ruby/Raisl Js/Ember Project](https://github.com/wildland/trailhead)
+- [New Ruby/Rails Ember Project](https://github.com/wildland/trailhead)
+- [New Ruby/Rails Plugin]](/rails_plugin/README.md)
 
 ## Releasing New Version
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Benjamin Franklin
 ## Starting New Projects
 
 - [New Ruby/Rails Ember Project](https://github.com/wildland/trailhead)
-- [New Ruby/Rails Plugin]](/rails_plugin/README.md)
+- [New Rails Plugin]](/rails_plugin/README.md)
 
 ## Releasing New Version
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Benjamin Franklin
 ## Starting New Projects
 
 - [New Ruby/Rails Ember Project](https://github.com/wildland/trailhead)
-- [New Rails Plugin]](/rails_plugin/README.md)
+- [New Rails Plugin](/rails_plugin/README.md)
 
 ## Releasing New Version
 

--- a/rails_plugin/README.md
+++ b/rails_plugin/README.md
@@ -1,0 +1,12 @@
+# Creating a new mountable Rails Engine
+
+```
+rails plugin new [plugin_name] --database=postgresql --mountable --dummy-path=spec/dummy --skip-test
+cd [pugin_name]
+```
+
+Add `s.add_development_dependency 'rspec-rails', '~> 3.7'` you your `[plugin_name].gemspec` file
+```
+bundle install
+bin/rails generate rspec:install
+```


### PR DESCRIPTION
Pretty straight forward, but this includes how to setup a new mountable rails engine rspec. We should probably update at some point to include plugins that do not mount, and a few other common setups, but this is a good start I think.